### PR TITLE
Windows's fix

### DIFF
--- a/src/main/java/com/jamierf/rxtx/RXTXLoader.java
+++ b/src/main/java/com/jamierf/rxtx/RXTXLoader.java
@@ -73,7 +73,7 @@ public class RXTXLoader {
             throw new IOException("Unsupported operating system or architecture");
 
 		final File tempDir = RXTXLoader.createTempDirectory();
-        final InputStream source = RXTXLoader.class.getResourceAsStream(os.toString().toLowerCase() + File.separator + arch.toString().toLowerCase() + File.separator + os.getLibPath());
+        final InputStream source = RXTXLoader.class.getResourceAsStream(os.toString().toLowerCase() + '/' + arch.toString().toLowerCase() + '/' + os.getLibPath());
         final File target = new File(tempDir, os.getLibPath());
 
         try {


### PR DESCRIPTION
Don't use OS's file separator for locating the native libs. On windows it's '\' instead of '/' and getResourceAsStream returns null
